### PR TITLE
[WIP] Downgrade PHP requirement from 7.1 to 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.0
   - 7.1
   - 7.2
   - 7.3

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ composer require brick/varexporter
 
 ### Requirements
 
-This library requires PHP 7.1 or later.
+This library requires PHP 7.0 or later.
 
 ### Project status & release process
 

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,11 @@
   ],
   "license": "MIT",
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.0",
     "nikic/php-parser": "^4.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0",
+    "phpunit/phpunit": "^6.0 || ^7.0",
     "php-coveralls/php-coveralls": "^2.0"
   },
   "autoload": {


### PR DESCRIPTION
(This PR is bad, and will be closed. I did something incorrectly in my env setup - the tests don't run correctly under 7.0.)

The code appears to be compatible with PHP 7.0, so this PR only includes changes to a few support files to allow installation and CI under PHP 7.0. Code coverage remains 100% under the older version of PHPUnit.

This is for people and organisations such as myself that run Debian stable in production environments, whose released PHP version is 7.0.