### PR TITLE
Supported exporting closures with use() variables

### DIFF
--- a/src/Internal/GenericExporter.php
+++ b/src/Internal/GenericExporter.php
@@ -49,6 +49,11 @@ final class GenericExporter
     public $inlineNumericScalarArray;
 
     /**
+     * @var bool
+     */
+    public $closureSnapshotUses;
+
+    /**
      * @param int $options
      */
     public function __construct(int $options)
@@ -76,6 +81,7 @@ final class GenericExporter
         $this->addTypeHints             = (bool) ($options & VarExporter::ADD_TYPE_HINTS);
         $this->skipDynamicProperties    = (bool) ($options & VarExporter::SKIP_DYNAMIC_PROPERTIES);
         $this->inlineNumericScalarArray = (bool) ($options & VarExporter::INLINE_NUMERIC_SCALAR_ARRAY);
+        $this->closureSnapshotUses         = (bool) ($options & VarExporter::CLOSURE_SNAPSHOT_USES);
     }
 
     /**

--- a/src/VarExporter.php
+++ b/src/VarExporter.php
@@ -54,6 +54,11 @@ final class VarExporter
     public const INLINE_NUMERIC_SCALAR_ARRAY = 1 << 7;
 
     /**
+     * Export static vars defined via `use` as variables.
+     */
+    public const CLOSURE_SNAPSHOT_USES = 1 << 8;
+
+    /**
      * @param mixed $var     The variable to export.
      * @param int   $options A bitmask of options. Possible values are `VarExporter::*` constants.
      *                       Combine multiple options with a bitwise OR `|` operator.


### PR DESCRIPTION
Added the ~~`CLOSURE_USE_AS_VAR`~~ `CLOSURE_SNAPSHOT_USE` option to allow exporting closures with `use()` variables. Reflection is used to get the (current) value of these variables. These are exported by the exporter, parsed and inserted as statements.

Example

```php
$planet = 'world';
echo VarExporter::export([
    'callback' => function() use ($planet) {
        return 'Hello, ' . $planet . '!';
    }
], VarExported::CLOSURE_SNAPSHOT_USE);
```
```php
[
    'callback' => function () {
        $planet = 'world';
        return 'Hello, ' . $planet . '!';
    }
]
```

Added `ClosureExporter::getParser()` method, not to create multiple parsers for exporting a single closure.