### PR TITLE
Support for arrow functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ echo VarExporter::export([
 
 ### Arrow functions
 
-PHP support a short hand syntax for closures (since PHP 7.4), also known as arrow functions. `VarExporter` will export these as normal closures.
+PHP supports shorthand syntax for closures (since PHP 7.4), also known as arrow functions. `VarExporter` will export these as normal closures.
 
 Arrow functions can implicitly use variables from the context they've been defined in. If any context variable is used in the arrow function, `VarExporter` will throw an `ExportException` unless the `CLOSURE_SNAPSHOT_USES` option is used.
 

--- a/README.md
+++ b/README.md
@@ -346,17 +346,40 @@ When using the `CLOSURE_SNAPSHOT_USE` option, `VarExporter` will export the curr
 $planet = 'world';
 
 echo VarExporter::export([
-    'callback' => function() use ($planet) {
-        return 'Hello, ' . $planet . '!';
+    'callback' => function(string $greeting) use ($planet) {
+        return $greeting . ', ' . $planet . '!';
     }
 ], VarExporter::CLOSURE_SNAPSHOT_USE);
 ```
 
 ```php
 [
-    'callback' => function () {
+    'callback' => function (string $greeting) {
         $planet = 'world';
-        return 'Hello, ' . $planet . '!';
+        return $greeting . ', ' . $planet . '!';
+    }
+]
+```
+
+### Arrow functions
+
+PHP support a short hand syntax for closures (since PHP 7.4), also known as arrow functions. `VarExporter` will export these as normal closures.
+
+Arrow functions can implicitly use variables from the context they've been defined in. If any context variable is used in the arrow function, `VarExporter` will throw an `ExportException` unless the `CLOSURE_SNAPSHOT_USES` option is used.
+
+```php
+$planet = 'world';
+
+echo VarExporter::export([
+    'callback' => fn(string $greeting) => $greeting . ', ' . $planet . '!';
+], VarExported::CLOSURE_SNAPSHOT_USES);
+```
+
+```php
+[
+    'callback' => function (string $greeting) {
+        $planet = 'world';
+        return $greeting . ', ' . $planet . '!';
     }
 ]
 ```

--- a/src/Internal/GenericExporter.php
+++ b/src/Internal/GenericExporter.php
@@ -81,7 +81,7 @@ final class GenericExporter
         $this->addTypeHints             = (bool) ($options & VarExporter::ADD_TYPE_HINTS);
         $this->skipDynamicProperties    = (bool) ($options & VarExporter::SKIP_DYNAMIC_PROPERTIES);
         $this->inlineNumericScalarArray = (bool) ($options & VarExporter::INLINE_NUMERIC_SCALAR_ARRAY);
-        $this->closureSnapshotUses         = (bool) ($options & VarExporter::CLOSURE_SNAPSHOT_USES);
+        $this->closureSnapshotUses      = (bool) ($options & VarExporter::CLOSURE_SNAPSHOT_USES);
     }
 
     /**

--- a/src/Internal/ObjectExporter/ClosureExporter.php
+++ b/src/Internal/ObjectExporter/ClosureExporter.php
@@ -225,13 +225,11 @@ class ClosureExporter extends ObjectExporter
         array $path
     ) : void {
         if (! $this->exporter->closureSnapshotUses) {
-            throw new ExportException(
-                "The closure has bound variables" .
-                    ($closure->hasAttribute('arrow_function') ? "" : " through 'use'") .
-                    ", this is not supported by default. " .
-                    "Use the CLOSURE_SNAPSHOT_USE option to export them.",
-                $path
-            );
+            $message = $closure->hasAttribute('arrow_function')
+                ? "The arrow function uses variables in the parent scope, this is not supported by default"
+                : "The closure has bound variables through 'use', this is not supported by default";
+
+            throw new ExportException("$message. Use the CLOSURE_SNAPSHOT_USE option to export them.", $path);
         }
 
         $static = $reflectionFunction->getStaticVariables();

--- a/src/Internal/ObjectExporter/ClosureExporter.php
+++ b/src/Internal/ObjectExporter/ClosureExporter.php
@@ -144,7 +144,7 @@ class ClosureExporter extends ObjectExporter
         array $path
     ) : Node\Expr\Closure {
         $finder = new FindingVisitor(function(Node $node) use ($line) : bool {
-            return $node instanceof Node\Expr\Closure
+            return ($node instanceof Node\Expr\Closure || $node instanceof Node\Expr\ArrowFunction)
                 && $node->getStartLine() === $line;
         });
 
@@ -164,11 +164,47 @@ class ClosureExporter extends ObjectExporter
             ), $path);
         }
 
-        /** @var Node\Expr\Closure $closure */
+        /** @var Node\Expr\Closure|Node\Expr\ArrowFunction $closure */
         $closure = $closures[0];
+
+        if ($closure instanceof Node\Expr\ArrowFunction) {
+            $closure = $this->convertArrowFunction($reflectionFunction, $closure);
+        }
 
         if ($closure->uses) {
             $this->closureHandleUses($reflectionFunction, $closure, $path);
+        }
+
+        return $closure;
+    }
+
+    /**
+     * Convert a parsed arrow function to a closure.
+     *
+     * @param ReflectionFunction       $reflectionFunction  Reflection of the closure.
+     * @param Node\Expr\ArrowFunction  $arrowFunction       Parsed arrow function.
+     * @param string[]                 $path                The path to the closure in the array/object graph.
+     *
+     * @return Node\Expr\Closure
+     */
+    private function convertArrowFunction(
+        ReflectionFunction $reflectionFunction,
+        Node\Expr\ArrowFunction $arrowFunction
+    ) : Node\Expr\Closure {
+        $closure = new Node\Expr\Closure([], ['arrow_function' => true]);
+
+        $closure->static = false;
+        $closure->params = $arrowFunction->params;
+        $closure->returnType = $arrowFunction->returnType;
+
+        $closure->stmts[] = new Node\Stmt\Return_($arrowFunction->expr);
+
+        $static = $reflectionFunction->getStaticVariables();
+
+        foreach (array_keys($static) as $var) {
+            $closure->uses[] = new Node\Expr\ClosureUse(
+                new Node\Expr\Variable($var)
+            );
         }
 
         return $closure;
@@ -190,7 +226,9 @@ class ClosureExporter extends ObjectExporter
     ) : void {
         if (! $this->exporter->closureSnapshotUses) {
             throw new ExportException(
-                "The closure has bound variables through 'use', this is not supported by default. " .
+                "The closure has bound variables" .
+                    ($closure->hasAttribute('arrow_function') ? "" : " through 'use'") .
+                    ", this is not supported by default. " .
                     "Use the `CLOSURE_SNAPSHOT_USE` option to export them.",
                 $path
             );

--- a/tests/ExportClosureTest.php
+++ b/tests/ExportClosureTest.php
@@ -235,8 +235,8 @@ PHP;
         $var = [fn ($planet) => $greet . ' ' . $planet];
 
         $this->assertExportThrows(
-            "The closure has bound variables, this is not supported by default. " .
-            "Use the `CLOSURE_SNAPSHOT_USE` option to export them.",
+            "The arrow function uses variables in the parent scope, this is not supported by default. " .
+            "Use the CLOSURE_SNAPSHOT_USE option to export them.",
             $var
         );
     }

--- a/tests/ExportClosureTest.php
+++ b/tests/ExportClosureTest.php
@@ -203,6 +203,67 @@ PHP;
         $this->assertExportEquals($expected, $var, VarExporter::ADD_RETURN | VarExporter::CLOSURE_SNAPSHOT_USES);
     }
 
+
+    public function testExportArrowFunction()
+    {
+        if (version_compare(PHP_VERSION, '7.4.0') < 0) {
+            $this->markTestSkipped("Arrow functions aren't supported in PHP " . PHP_VERSION);
+        }
+
+        $var = [fn ($planet) => 'hello ' . $planet]; // Wrapping in array for valid syntax PHP <7.4
+
+        $expected = <<<'PHP'
+return [
+    function ($planet) {
+        return 'hello ' . $planet;
+    }
+];
+
+PHP;
+
+        $this->assertExportEquals($expected, $var, VarExporter::ADD_RETURN);
+    }
+
+    public function testExportArrowFunctionWithContext()
+    {
+        if (version_compare(PHP_VERSION, '7.4.0') < 0) {
+            $this->markTestSkipped("Arrow functions aren't supported in PHP " . PHP_VERSION);
+        }
+
+        $greet = 'hello';
+
+        $var = [fn ($planet) => $greet . ' ' . $planet];
+
+        $this->assertExportThrows(
+            "The closure has bound variables, this is not supported by default. " .
+            "Use the `CLOSURE_SNAPSHOT_USE` option to export them.",
+            $var
+        );
+    }
+
+    public function testExportArrowFunctionWithContextVarAsVar()
+    {
+        if (version_compare(PHP_VERSION, '7.4.0') < 0) {
+            $this->markTestSkipped("Arrow functions aren't supported in PHP " . PHP_VERSION);
+        }
+
+        $greet = 'hello';
+
+        $var = [fn ($planet) => $greet . ' ' . $planet];
+
+        $expected = <<<'PHP'
+return [
+    function ($planet) {
+        $greet = 'hello';
+        return $greet . ' ' . $planet;
+    }
+];
+
+PHP;
+
+        $this->assertExportEquals($expected, $var, VarExporter::ADD_RETURN | VarExporter::CLOSURE_SNAPSHOT_USES);
+    }
+
     public function testExportClosureDefinedInEval()
     {
         $var = eval(<<<PHP


### PR DESCRIPTION
_This PR includes the commit of #7_

Support shorthand syntax for closures aka arrow functions by converting them to regular closures.

Reflection is used to check if the arrow function uses any context variable. These are converted to `use()` variables for the closure.

Example;

```php
$planet = 'world';

echo VarExporter::export([
    'callback' => fn(string $greeting) => $greeting . ', ' . $planet . '!';
], VarExported::CLOSURE_SNAPSHOT_USES);
```

```php
[
    'callback' => function (string $greeting) {
        $planet = 'world';
        return $greeting . ', ' . $planet . '!';
    }
]
```