### PR TITLE
Add support for trailing comma in arrays.

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,31 @@ VarExporter::export([
 
 Types considered scalar here are `int`, `bool`, `float`, `string` and `null`.
 
+### `VarExporter::TRAILING_COMMA_IN_ARRAY`
+
+Add trailing comma for last item of an array:
+
+```php
+VarExporter::export([
+    'one' => ['hello', 'world', 123, true, false, null, 7.5],
+    'two' => ['hello', 'world', ['one', 'two', 'three']]
+], VarExporter::TRAILING_COMMA_IN_ARRAY | VarExporter::INLINE_NUMERIC_SCALAR_ARRAY);
+```
+
+```php
+[
+    'one' => ['hello', 'world', 123, true, false, null, 7.5],
+    'two' => [
+        'hello',
+        'world',
+        ['one', 'two', 'three'],
+    ],
+]
+```
+
+Trailing comma won't be added to inlined arrays if this flag is used along with
+`VarExporter::INLINE_NUMERIC_SCALAR_ARRAY`.
+
 ### `VarExporter::CLOSURE_SNAPSHOT_USES`
 
 Export the current value of each `use()` variable as expression inside the exported closure.

--- a/src/Internal/GenericExporter.php
+++ b/src/Internal/GenericExporter.php
@@ -53,6 +53,11 @@ final class GenericExporter
     public $closureSnapshotUses;
 
     /**
+     * @var bool
+     */
+    public $trailingCommaInArray;
+
+    /**
      * @param int $options
      */
     public function __construct(int $options)
@@ -81,6 +86,7 @@ final class GenericExporter
         $this->skipDynamicProperties    = (bool) ($options & VarExporter::SKIP_DYNAMIC_PROPERTIES);
         $this->inlineNumericScalarArray = (bool) ($options & VarExporter::INLINE_NUMERIC_SCALAR_ARRAY);
         $this->closureSnapshotUses      = (bool) ($options & VarExporter::CLOSURE_SNAPSHOT_USES);
+        $this->trailingCommaInArray     = (bool) ($options & VarExporter::TRAILING_COMMA_IN_ARRAY);
     }
 
     /**
@@ -163,7 +169,7 @@ final class GenericExporter
                     $prepend = var_export($key, true) . ' => ';
                 }
 
-                if (! $isLast) {
+                if (! $isLast || $this->trailingCommaInArray) {
                     $append = ',';
                 }
 

--- a/src/VarExporter.php
+++ b/src/VarExporter.php
@@ -60,6 +60,7 @@ final class VarExporter
 
     /**
      * Add trailing comma for last item of an array.
+     * Trailing comma won't be added to inlined arrays even if this flag is used.
      */
     public const TRAILING_COMMA_IN_ARRAY = 1 << 9;
 

--- a/src/VarExporter.php
+++ b/src/VarExporter.php
@@ -59,6 +59,11 @@ final class VarExporter
     public const CLOSURE_SNAPSHOT_USES = 1 << 8;
 
     /**
+     * Add trailing comma for last item of an array.
+     */
+    public const TRAILING_COMMA_IN_ARRAY = 1 << 9;
+
+    /**
      * @param mixed $var     The variable to export.
      * @param int   $options A bitmask of options. Possible values are `VarExporter::*` constants.
      *                       Combine multiple options with a bitwise OR `|` operator.

--- a/tests/VarExporterTest.php
+++ b/tests/VarExporterTest.php
@@ -151,6 +151,27 @@ PHP;
         $this->assertExportEquals($expected, $var, VarExporter::INLINE_NUMERIC_SCALAR_ARRAY);
     }
 
+    public function testTrailingCommaInArray()
+    {
+        $var = [
+            'one' => ['hello', 'world', 123, true, false, null, 7.5],
+            'two' => ['hello', 'world', ['one', 'two', 'three']]
+        ];
+
+        $expected = <<<'PHP'
+[
+    'one' => ['hello', 'world', 123, true, false, null, 7.5],
+    'two' => [
+        'hello',
+        'world',
+        ['one', 'two', 'three'],
+    ],
+]
+PHP;
+
+        $this->assertExportEquals($expected, $var, VarExporter::INLINE_NUMERIC_SCALAR_ARRAY | VarExporter::TRAILING_COMMA_IN_ARRAY);
+    }
+
     public function testExportDateTime()
     {
         $timezone = new \DateTimeZone('Europe/Berlin');


### PR DESCRIPTION
Trailing comma won't be added to inlined arrays even if trailing comma option being enabled.