### PR TITLE
Add argument to control the indentation level.

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,31 @@ VarExporter::export(
 
 Export the current value of each `use()` variable as expression inside the exported closure.
 
+## Indentation
+
+You can use the 3rd argument of `VarExporter::export()` to control the indentation level. 
+This is useful when you want to use the generated code string to replace a placeholder in a template used to generate code files.
+
+So using output of `VarExporter::export(['foo' => 'bar'], 0, 1)` in the template below to replace `{{exported}}`
+
+```
+public foo() 
+{
+    $data = {{exported}};
+}
+```
+
+would result in
+
+```php
+public foo() 
+{
+    $data = [
+        'foo' => 'bar'
+    ];
+}
+```
+
 ## Error handling
 
 Any error occurring on `export()` will throw an `ExportException`:

--- a/src/Internal/GenericExporter.php
+++ b/src/Internal/GenericExporter.php
@@ -68,9 +68,17 @@ final class GenericExporter
     public $trailingCommaInArray;
 
     /**
-     * @param int $options
+     * @psalm-readonly
+     *
+     * @var int
      */
-    public function __construct(int $options)
+    public $indentLevel;
+
+    /**
+     * @param int $options
+     * @param int Indentation level
+     */
+    public function __construct(int $options, int $indentLevel = 0)
     {
         $this->objectExporters[] = new ObjectExporter\StdClassExporter($this);
 
@@ -97,6 +105,8 @@ final class GenericExporter
         $this->inlineNumericScalarArray = (bool) ($options & VarExporter::INLINE_NUMERIC_SCALAR_ARRAY);
         $this->closureSnapshotUses      = (bool) ($options & VarExporter::CLOSURE_SNAPSHOT_USES);
         $this->trailingCommaInArray     = (bool) ($options & VarExporter::TRAILING_COMMA_IN_ARRAY);
+
+        $this->indentLevel = $indentLevel;
     }
 
     /**

--- a/src/Internal/ObjectExporter/ClosureExporter.php
+++ b/src/Internal/ObjectExporter/ClosureExporter.php
@@ -54,7 +54,7 @@ class ClosureExporter extends ObjectExporter
         $closure = $this->getClosure($reflectionFunction, $ast, $file, $line, $path);
 
         $prettyPrinter = new ClosureExporter\PrettyPrinter();
-        $prettyPrinter->setVarExporterNestingLevel(count($path));
+        $prettyPrinter->setVarExporterNestingLevel(count($path) + $this->exporter->indentLevel);
 
         $code = $prettyPrinter->prettyPrintExpr($closure);
 

--- a/src/VarExporter.php
+++ b/src/VarExporter.php
@@ -75,7 +75,7 @@ final class VarExporter
      */
     public static function export($var, int $options = 0, int $indentLevel = 0) : string
     {
-        $exporter = new GenericExporter($options);
+        $exporter = new GenericExporter($options, $indentLevel);
         $lines = $exporter->export($var, [], []);
 
         if ($indentLevel < 1 || count($lines) < 2) {

--- a/src/VarExporter.php
+++ b/src/VarExporter.php
@@ -64,23 +64,33 @@ final class VarExporter
     public const TRAILING_COMMA_IN_ARRAY = 1 << 9;
 
     /**
-     * @param mixed $var     The variable to export.
-     * @param int   $options A bitmask of options. Possible values are `VarExporter::*` constants.
-     *                       Combine multiple options with a bitwise OR `|` operator.
+     * @param mixed $var       The variable to export.
+     * @param int   $options   A bitmask of options. Possible values are `VarExporter::*` constants.
+     *                         Combine multiple options with a bitwise OR `|` operator.
+     * @param int $indentLevel Indentation level.
      *
      * @return string
      *
      * @throws ExportException
      */
-    public static function export($var, int $options = 0) : string
+    public static function export($var, int $options = 0, int $indentLevel = 0) : string
     {
         $exporter = new GenericExporter($options);
-
         $lines = $exporter->export($var, [], []);
-        $export = implode(PHP_EOL, $lines);
+
+        if ($indentLevel < 1 || count($lines) < 2) {
+            $export = implode(PHP_EOL, $lines);
+        } else {
+            $firstLine = array_shift($lines);
+            $lines = array_map(function ($line) use ($indentLevel) {
+                return str_repeat('    ', $indentLevel) . $line;
+            }, $lines);
+
+            $export = $firstLine . PHP_EOL . implode(PHP_EOL, $lines);
+        }
 
         if ($options & self::ADD_RETURN) {
-            return 'return ' . $export . ';' .  PHP_EOL;
+            return 'return ' . $export . ';' . PHP_EOL;
         }
 
         return $export;

--- a/tests/VarExporterTest.php
+++ b/tests/VarExporterTest.php
@@ -287,4 +287,52 @@ PHP;
             ]
         ]);
     }
+
+    public function testExportIndented()
+    {
+        $exported = VarExporter::export(
+            ['one' => ['hello', true], 'two' => 2],
+            0,
+            1
+        );
+
+        $template = <<<TPL
+public foo ()
+{
+    \$data = $exported;
+}
+TPL;
+        $expected = <<<'PHP'
+public foo ()
+{
+    $data = [
+        'one' => [
+            'hello',
+            true
+        ],
+        'two' => 2
+    ];
+}
+PHP;
+
+        $this->assertEquals($expected, $template);
+    }
+
+    public function testExportIndented2()
+    {
+        $exported = VarExporter::export(null, 0, 1);
+        $template = <<<TPL
+public foo ()
+{
+    \$data = $exported;
+}
+TPL;
+        $expected = <<<'PHP'
+public foo ()
+{
+    $data = null;
+}
+PHP;
+        $this->assertEquals($expected, $template);
+    }
 }


### PR DESCRIPTION
POC for generating exported code with additional indentation.

The idea is to be able to replace placeholder in templates with the exported code string and end up with properly indented PHP code in the generated file.

So using output of `VarExporter::exportIndented(['foo' => 'bar'], 0, 1)` in template below

```twig
public foo () 
{
    $aVar = {{exported}};
}
```

would result in

```php
public foo () 
{
    $aVar = [
        'foo' => 'bar'
    ];
}
```

I can finish up the PR if you like the idea in general.