### PR TITLE
Add option to generate inlined arrays.

### DIFF
--- a/src/VarExporter.php
+++ b/src/VarExporter.php
@@ -64,6 +64,11 @@ final class VarExporter
     public const TRAILING_COMMA_IN_ARRAY = 1 << 9;
 
     /**
+     * Formats arrays on a single line.
+     */
+    public const INLINE_ARRAY = 1 << 10;
+
+    /**
      * @param mixed $var       The variable to export.
      * @param int   $options   A bitmask of options. Possible values are `VarExporter::*` constants.
      *                         Combine multiple options with a bitwise OR `|` operator.

--- a/tests/VarExporterTest.php
+++ b/tests/VarExporterTest.php
@@ -172,6 +172,28 @@ PHP;
         $this->assertExportEquals($expected, $var, VarExporter::INLINE_NUMERIC_SCALAR_ARRAY | VarExporter::TRAILING_COMMA_IN_ARRAY);
     }
 
+    public function testInlineArray()
+    {
+        $var = ['one' => [1], 'two' => ['a2' => 'v2', 'a1']];
+        $scalarValues = "'one' => [1], 'two' => ['a2' => 'v2', 0 => 'a1']";
+        $expected = '[' . $scalarValues . ']';
+
+        $this->assertExportEquals($expected, $var, VarExporter::INLINE_ARRAY | VarExporter::TRAILING_COMMA_IN_ARRAY);
+
+        $myObject = new PublicPropertiesOnly();
+        $myObject->foo = 'hello';
+        $myObject->bar = new SetState();
+        $myObject->bar->foo = 'SetState.foo';
+        $myObject->bar->bar = 'SetState.bar';
+
+        $var['myObject'] = $myObject;
+
+        $objectValue = "'myObject' => (static function() { \$object = new \Brick\VarExporter\Tests\Classes\PublicPropertiesOnly;  \$object->foo = 'hello'; \$object->bar = \Brick\VarExporter\Tests\Classes\SetState::__set_state(['baz' => 'defaultValue', 'foo' => 'SetState.foo', 'bar' => 'SetState.bar']);  return \$object; })()";
+        $expected = '[' . $scalarValues . ', ' . $objectValue . ']';
+
+        $this->assertExportEquals($expected, $var, VarExporter::INLINE_ARRAY | VarExporter::TRAILING_COMMA_IN_ARRAY);
+    }
+
     public function testExportDateTime(): void
     {
         $timezone = new \DateTimeZone('Europe/Berlin');


### PR DESCRIPTION
The `INLINE_ARRAY` option super seeds the `INLINE_NUMERIC_SCALAR_ARRAY` option
and will inline even associative arrays.