### PR TITLE
Add support for exporting Enums when using PHP8.1+

### DIFF
--- a/src/Internal/GenericExporter.php
+++ b/src/Internal/GenericExporter.php
@@ -96,6 +96,10 @@ final class GenericExporter
             $this->objectExporters[] = new ObjectExporter\SerializeExporter($this);
         }
 
+        if (! ($options & VarExporter::NO_ENUMS)) {
+            $this->objectExporters[] = new ObjectExporter\EnumExporter($this);
+        }
+
         if (! ($options & VarExporter::NOT_ANY_OBJECT)) {
             $this->objectExporters[] = new ObjectExporter\AnyObjectExporter($this);
         }

--- a/src/Internal/ObjectExporter/EnumExporter.php
+++ b/src/Internal/ObjectExporter/EnumExporter.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\VarExporter\Internal\ObjectExporter;
+
+use Brick\VarExporter\Internal\ObjectExporter;
+use UnitEnum;
+
+/**
+ * Handles enums.
+ *
+ * @internal This class is for internal use, and not part of the public API. It may change at any time without warning.
+ */
+class EnumExporter extends ObjectExporter
+{
+    /**
+     * {@inheritDoc}
+     *
+     * See: https://github.com/vimeo/psalm/pull/8117
+     * @psalm-suppress MixedInferredReturnType
+     * @psalm-suppress MixedReturnStatement
+     */
+    public function supports(\ReflectionObject $reflectionObject) : bool
+    {
+        if (! method_exists($reflectionObject, 'isEnum')) {
+            return false;
+        }
+
+        return $reflectionObject->isEnum();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function export(object $object, \ReflectionObject $reflectionObject, array $path, array $parentIds) : array
+    {
+        assert($object instanceof UnitEnum);
+
+        return [
+            get_class($object) . '::' . $object->name
+        ];
+    }
+}

--- a/src/VarExporter.php
+++ b/src/VarExporter.php
@@ -64,6 +64,11 @@ final class VarExporter
     public const TRAILING_COMMA_IN_ARRAY = 1 << 9;
 
     /**
+     * Disallows exporting enums.
+     */
+    public const NO_ENUMS = 1 << 10;
+
+    /**
      * @param mixed $var       The variable to export.
      * @param int   $options   A bitmask of options. Possible values are `VarExporter::*` constants.
      *                         Combine multiple options with a bitwise OR `|` operator.

--- a/tests/Classes/Enum.php
+++ b/tests/Classes/Enum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\VarExporter\Tests\Classes;
+
+enum Enum
+{
+    case TEST;
+}

--- a/tests/ExportObjectTest.php
+++ b/tests/ExportObjectTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Brick\VarExporter\Tests;
 
 use Brick\VarExporter\Tests\Classes\ConstructorAndNoProperties;
+use Brick\VarExporter\Tests\Classes\Enum;
 use Brick\VarExporter\Tests\Classes\NoProperties;
 use Brick\VarExporter\Tests\Classes\Hierarchy;
 use Brick\VarExporter\Tests\Classes\PublicPropertiesWithConstructor;
@@ -543,5 +544,19 @@ PHP;
             'using the current options.';
 
         $this->assertExportThrows($expectedMessage, $object, VarExporter::NOT_ANY_OBJECT);
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testExportEnum(): void
+    {
+        $object = Enum::TEST;
+
+        $expected = <<<'PHP'
+Brick\VarExporter\Tests\Classes\Enum::TEST
+PHP;
+
+        $this->assertExportEquals($expected, $object);
     }
 }


### PR DESCRIPTION
This enables support for exporting Enums when using PHP8.1+

Enums are considered objects which cannot be instantiated, this caused a fatal error when using the var exporter:
```
      Error::("Cannot instantiate enum XY")
```

This pull requests enables support for exporting Enums, disabling exporting of Enums & keeps support for previous PHP versions without breaking changes.