### PR TITLE
Drop php version support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         deps:
           - "highest"
         include:
-          - php-version: "7.4"
+          - php-version: "8.1"
             deps: "lowest"
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.4"
-          - "8.0"
           - "8.1"
           - "8.2"
           - "8.3"

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ composer require brick/varexporter
 
 ### Requirements
 
-This library requires PHP 7.4 or later.
+This library requires PHP 8.1 or later.
 
-For PHP 7.2 & 7.3 compatibility, you can use version `0.3`. For PHP 7.1, you can use version `0.2`. Note that [these PHP versions are EOL](http://php.net/supported-versions.php) and not supported anymore. If you're still using one of these PHP versions, you should consider upgrading as soon as possible.
+For PHP 7.4, you can use version `0.5`. For PHP 7.2 & 7.3 compatibility, you can use version `0.3`. Note that [these PHP versions are EOL](http://php.net/supported-versions.php) and not supported anymore. If you're still using one of these PHP versions, you should consider upgrading as soon as possible.
 
 ### Project status & release process
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   ],
   "license": "MIT",
   "require": {
-    "php": "^7.4 || ^8.0",
+    "php": "^8.1",
     "nikic/php-parser": "^5.0"
   },
   "require-dev": {

--- a/src/Internal/ObjectExporter/SetStateExporter.php
+++ b/src/Internal/ObjectExporter/SetStateExporter.php
@@ -76,8 +76,6 @@ class SetStateExporter extends ObjectExporter
                 $name = substr($name, $pos + 1);
             }
 
-            assert($name !== false);
-
             if (array_key_exists($name, $result)) {
                 $className = get_class($object);
 

--- a/tests/ExportClosureTest.php
+++ b/tests/ExportClosureTest.php
@@ -206,10 +206,6 @@ PHP;
 
     public function testExportArrowFunction(): void
     {
-        if (version_compare(PHP_VERSION, '7.4.0') < 0) {
-            $this->markTestSkipped("Arrow functions aren't supported in PHP " . PHP_VERSION);
-        }
-
         $var = [fn ($planet) => 'hello ' . $planet]; // Wrapping in array for valid syntax PHP <7.4
 
         $expected = <<<'PHP'
@@ -226,10 +222,6 @@ PHP;
 
     public function testExportArrowFunctionWithContext(): void
     {
-        if (version_compare(PHP_VERSION, '7.4.0') < 0) {
-            $this->markTestSkipped("Arrow functions aren't supported in PHP " . PHP_VERSION);
-        }
-
         $greet = 'hello';
 
         $var = [fn ($planet) => $greet . ' ' . $planet];
@@ -243,10 +235,6 @@ PHP;
 
     public function testExportArrowFunctionWithContextVarAsVar(): void
     {
-        if (version_compare(PHP_VERSION, '7.4.0') < 0) {
-            $this->markTestSkipped("Arrow functions aren't supported in PHP " . PHP_VERSION);
-        }
-
         $greet = 'hello';
 
         $var = [fn ($planet) => $greet . ' ' . $planet];


### PR DESCRIPTION
Drops support for PHP versions below 8.0.

Cleaned up the test case cause the skipped test checks are not required anymore (they were obsolete before as well).